### PR TITLE
Add JSON-RPC Error Code Constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive CLAUDE.md project guidance for AI-assisted development
 - GitHub issue templates for planned improvements (9 issues)
 - Code documentation comments (route sorting explanation)
+- `JsonRpcErrorCode` class with named constants for JSON-RPC 2.0 error codes
+- Documentation section in README with error code reference
+
+### Changed
+- WebSocket error handling now uses `JsonRpcErrorCode` constants instead of magic numbers
+- METHOD_NOT_FOUND error now correctly uses error code -32601 (was incorrectly -32600)
+- Error messages for method not found now include the method name
 
 ### Fixed
 - pytest-cov dependency (was incorrectly named pytest-coverage)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ async def main():
 
 Call any PostgreSQL function using the same JSON-RPC protocol shown above. An authenticated variant (`AuthPostgresRPC`) is available for automatic user injection. See `samples/postgres_rpc_demo/` for complete examples.
 
+## JSON-RPC Error Codes
+
+Gust provides standard JSON-RPC 2.0 error codes as constants:
+
+```python
+from blueshed.gust import JsonRpcErrorCode
+from blueshed.gust.utils import JsonRpcException
+
+# Use constants instead of magic numbers
+raise JsonRpcException(
+    JsonRpcErrorCode.INVALID_PARAMS,
+    "Missing required parameter: user_id"
+)
+```
+
+Available error codes:
+- `PARSE_ERROR` (-32700): Invalid JSON
+- `INVALID_REQUEST` (-32600): Invalid JSON-RPC request
+- `METHOD_NOT_FOUND` (-32601): Method doesn't exist
+- `INVALID_PARAMS` (-32602): Invalid parameters
+- `INTERNAL_ERROR` (-32603): Internal server error
+
 There are simple sample apps in src/tests.
 
 ## Documentation

--- a/src/blueshed/gust/__init__.py
+++ b/src/blueshed/gust/__init__.py
@@ -8,7 +8,7 @@ from .postgres_rpc import AuthPostgresRPC, PostgresRPC
 from .routes import Routes
 from .static_file_handler import AuthStaticFileHandler
 from .stream import Stream
-from .utils import Redirect, stream
+from .utils import JsonRpcErrorCode, Redirect, stream
 from .web import web
 
 VERSION = '0.0.26'
@@ -24,4 +24,5 @@ __all__ = [
     'AuthStaticFileHandler',
     'PostgresRPC',
     'AuthPostgresRPC',
+    'JsonRpcErrorCode',
 ]

--- a/src/blueshed/gust/utils.py
+++ b/src/blueshed/gust/utils.py
@@ -35,6 +35,34 @@ class JsonRpcException(Exception):
         return {'code': self.js_code, 'message': self.js_message}
 
 
+class JsonRpcErrorCode:
+    """
+    JSON-RPC 2.0 error codes as defined in the specification.
+
+    See: https://www.jsonrpc.org/specification#error_object
+
+    Standard JSON-RPC 2.0 errors:
+    - PARSE_ERROR (-32700): Invalid JSON was received
+    - INVALID_REQUEST (-32600): The JSON sent is not a valid Request object
+    - METHOD_NOT_FOUND (-32601): The method does not exist / is not available
+    - INVALID_PARAMS (-32602): Invalid method parameter(s)
+    - INTERNAL_ERROR (-32603): Internal JSON-RPC error
+
+    Server errors (-32000 to -32099) are reserved for implementation-defined
+    server errors.
+    """
+
+    # Standard JSON-RPC 2.0 errors
+    PARSE_ERROR = -32700  # Invalid JSON
+    INVALID_REQUEST = -32600  # Invalid JSON-RPC request
+    METHOD_NOT_FOUND = -32601  # Method does not exist
+    INVALID_PARAMS = -32602  # Invalid method parameters
+    INTERNAL_ERROR = -32603  # Internal JSON-RPC error
+
+    # Server errors (-32000 to -32099 reserved for implementation-defined)
+    # Add custom error codes here if needed in the future
+
+
 @dataclass
 class JsonRpcResponse:
     """

--- a/src/tests/test_web.py
+++ b/src/tests/test_web.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from tornado.template import DictLoader
 
-from blueshed.gust import Gust, json_utils, web
+from blueshed.gust import Gust, JsonRpcErrorCode, json_utils, web
 
 PATH = '/foo/'
 
@@ -187,9 +187,10 @@ async def test_mising_method(ws_client, caplog):
         await asyncio.sleep(0.01)
     response = await client.read_message()
     print(response)
-    assert {'code': -32600, 'message': 'no method'} == json_utils.loads(
-        response
-    )['error']
+    assert {
+        'code': JsonRpcErrorCode.INVALID_REQUEST,
+        'message': 'no method',
+    } == json_utils.loads(response)['error']
     client.close()
     await asyncio.sleep(0.01)
 
@@ -208,9 +209,9 @@ async def test_not_method(ws_client, caplog):
         await asyncio.sleep(0.01)
     response = await client.read_message()
     print(response)
-    assert {'code': -32600, 'message': 'not method'} == json_utils.loads(
-        response
-    )['error']
+    error = json_utils.loads(response)['error']
+    assert error['code'] == JsonRpcErrorCode.METHOD_NOT_FOUND
+    assert 'Method not found: foo' == error['message']
     client.close()
     await asyncio.sleep(0.01)
 


### PR DESCRIPTION
Replace magic numbers with named constants for better code readability and maintainability.

Added:
- JsonRpcErrorCode class with standard JSON-RPC 2.0 error codes:
  - PARSE_ERROR (-32700)
  - INVALID_REQUEST (-32600)
  - METHOD_NOT_FOUND (-32601)
  - INVALID_PARAMS (-32602)
  - INTERNAL_ERROR (-32603)
- Exported JsonRpcErrorCode from __init__.py for public API
- Documentation in README with usage examples
- Comprehensive docstring with JSON-RPC spec link

Changed:
- websocket.py now uses constants instead of magic numbers
- Fixed incorrect error code: method not found now uses -32601 (was incorrectly using -32600)
- Improved error message: includes method name when not found

Updated:
- Tests now use constants for better clarity
- CHANGELOG.md documents all changes
- All error code references updated

This improves code quality by:
- Making error codes self-documenting
- Enabling IDE autocomplete
- Preventing typos in error codes
- Following JSON-RPC 2.0 specification

Closes issue #4 (if created)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Standardised JSON-RPC 2.0 error codes now documented with practical usage examples

* **Bug Fixes**
  * Error messages for method-not-found responses now include the method name for improved debugging
  * Corrected error code assignment for method-not-found cases

* **Documentation**
  * Added comprehensive reference section for available error codes with descriptions and numeric values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->