### PR TITLE
Enhance postgres_rpc_demo logging for better visibility

### DIFF
--- a/samples/postgres_rpc_demo/server.py
+++ b/samples/postgres_rpc_demo/server.py
@@ -28,10 +28,15 @@ sys.path.insert(0, '../../src')
 from blueshed.gust import AuthPostgresRPC, Gust, PostgresRPC, web
 
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.DEBUG,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
 )
 log = logging.getLogger(__name__)
+
+# Enable DEBUG logging for Gust modules to see request/response activity
+logging.getLogger('blueshed.gust').setLevel(logging.DEBUG)
+logging.getLogger('tornado.access').setLevel(logging.INFO)
+logging.getLogger('tornado.application').setLevel(logging.DEBUG)
 
 # Global connection
 _conn = None

--- a/src/blueshed/gust/postgres_rpc.py
+++ b/src/blueshed/gust/postgres_rpc.py
@@ -143,7 +143,7 @@ class PostgresRPC:
                 result = await cur.fetchone()
             # Return first column of first row, or None
             return result[0] if result else None
-        except Exception as e:
+        except Exception:
             # Rollback failed transaction to reset connection state
             try:
                 await self.connection.rollback()

--- a/src/tests/test_postgres_rpc.py
+++ b/src/tests/test_postgres_rpc.py
@@ -18,7 +18,6 @@ from psycopg import AsyncConnection
 
 from blueshed.gust.postgres_rpc import (
     _FUNCTION_SIGNATURE_CACHE,
-    AuthPostgresRPC,
     PostgresRPC,
 )
 

--- a/src/tests/test_ws_stream.py
+++ b/src/tests/test_ws_stream.py
@@ -76,7 +76,7 @@ async def test_places(ws_client, caplog):
         }
         await ws_client.write_message(json_utils.dumps(message))
         await asyncio.sleep(0.01)
-        msg = await ws_client.read_message()
+        await ws_client.read_message()
         for _ in range(4):
             data = await ws_client.read_message()
             result: dict = json_utils.loads(data)


### PR DESCRIPTION
## Summary

Improves logging visibility in the postgres_rpc_demo sample to help developers see what's happening when making requests.

## Changes

- Enable DEBUG logging level to see detailed activity
- Add DEBUG logging for `blueshed.gust` modules to show WebSocket and JSON-RPC activity
- Add DEBUG logging for `tornado.application` to see request handling
- Keep INFO level for `tornado.access` to see HTTP access logs

## Benefits

Developers can now see:
- WebSocket connection/disconnection events
- JSON-RPC method calls with parameters
- PostgreSQL function execution
- Request/response flow

## Testing

Run the demo server and make requests - you'll now see detailed logging output:
```bash
python samples/postgres_rpc_demo/server.py
```

## Type

- [x] Enhancement
- [ ] Bug fix
- [ ] Documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging configuration in the demo server environment to provide improved diagnostic visibility for development and troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->